### PR TITLE
feat: terrible_host_group resource

### DIFF
--- a/terrible_provider/discovery.py
+++ b/terrible_provider/discovery.py
@@ -50,8 +50,15 @@ _FRAMEWORK_ATTRS = [
     Attribute(
         "host_id",
         String(),
-        description="ID of the `terrible_host` to run this task against",
-        required=True,
+        description="ID of the `terrible_host` to run this task against. Mutually exclusive with host_group_id.",
+        optional=True,
+        requires_replace=True,
+    ),
+    Attribute(
+        "host_group_id",
+        String(),
+        description="ID of the `terrible_host_group` to run this task against. Mutually exclusive with host_id.",
+        optional=True,
         requires_replace=True,
     ),
     Attribute("result", NormalizedJson(), description="Full raw JSON result from Ansible", computed=True),

--- a/terrible_provider/host_group.py
+++ b/terrible_provider/host_group.py
@@ -1,0 +1,55 @@
+import uuid
+from typing import Optional
+
+from tf.schema import Schema, Attribute
+from tf.types import NormalizedJson, String
+from tf.iface import Resource, CreateContext, ReadContext, UpdateContext, DeleteContext, ImportContext
+
+
+class TerribleHostGroup(Resource):
+    """A named group of terrible_host IDs for targeting tasks across multiple hosts."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "host_group"
+
+    @classmethod
+    def get_schema(cls) -> Schema:
+        return Schema(
+            attributes=[
+                Attribute("id", String(), description="Unique host group ID", computed=True),
+                Attribute(
+                    "host_ids",
+                    NormalizedJson(),
+                    description="List of terrible_host IDs to include in this group.",
+                    required=True,
+                ),
+            ]
+        )
+
+    def __init__(self, provider):
+        self._prov = provider
+
+    def create(self, ctx: CreateContext, planned: dict) -> Optional[dict]:
+        new_id = uuid.uuid4().hex
+        state = {**planned, "id": new_id}
+        self._prov._state[new_id] = state
+        self._prov._save_state()
+        return state
+
+    def read(self, ctx: ReadContext, current: dict) -> Optional[dict]:
+        return self._prov._state.get(current.get("id"))
+
+    def update(self, ctx: UpdateContext, current: dict, planned: dict) -> Optional[dict]:
+        rid = current["id"]
+        state = {**planned, "id": rid}
+        self._prov._state[rid] = state
+        self._prov._save_state()
+        return state
+
+    def delete(self, ctx: DeleteContext, current: dict):
+        self._prov._state.pop(current.get("id"), None)
+        self._prov._save_state()
+
+    def import_(self, ctx: ImportContext, id: str) -> Optional[dict]:
+        return self._prov._state.get(id)

--- a/terrible_provider/provider.py
+++ b/terrible_provider/provider.py
@@ -10,6 +10,7 @@ from tf.utils import Diagnostics
 from tf.iface import Provider
 
 from .host import TerribleHost
+from .host_group import TerribleHostGroup
 from .play import TerriblePlaybook, TerribleRole
 from .vault import TerribleVault
 from .discovery import discover_task_resources
@@ -95,4 +96,4 @@ class TerribleProvider(Provider):
 
     def get_resources(self) -> list:
         self._ensure_discovered()
-        return [TerribleHost, TerriblePlaybook, TerribleRole, *self._task_resources]
+        return [TerribleHost, TerribleHostGroup, TerriblePlaybook, TerribleRole, *self._task_resources]

--- a/terrible_provider/task_base.py
+++ b/terrible_provider/task_base.py
@@ -234,7 +234,7 @@ def _run_module(
 
 
 _SKIP_ATTRS = frozenset({
-    "id", "host_id", "result", "changed", "triggers",
+    "id", "host_id", "host_group_id", "result", "changed", "triggers",
     "timeout", "ignore_errors", "changed_when", "failed_when",
     "environment", "tags", "skip_tags",
     "async_seconds", "poll_interval",
@@ -301,7 +301,25 @@ class TerribleTaskBase(Resource):
             )
         return h
 
+    def _validate_host_target(self, diags, planned: dict) -> bool:
+        """Return True iff exactly one of host_id / host_group_id is set."""
+        has_host = bool(planned.get("host_id"))
+        has_group = bool(planned.get("host_group_id"))
+        if has_host == has_group:
+            diags.add_error(
+                "Exactly one of host_id or host_group_id must be set",
+                "Set host_id to target a single host or host_group_id to target a group.",
+            )
+            return False
+        return True
+
     def _execute(self, diags, planned: dict) -> tuple[dict, bool, dict]:
+        if not self._validate_host_target(diags, planned):
+            return {}, False, {}
+
+        if planned.get("host_group_id"):
+            return self._execute_group(diags, planned)
+
         host = self._resolve_host(planned["host_id"], diags)
         if host is None:
             return {}, False, {}
@@ -338,6 +356,59 @@ class TerribleTaskBase(Resource):
         }
         return result, changed, return_attrs
 
+    def _execute_group(self, diags, planned: dict) -> tuple[dict, bool, dict]:
+        """Run the module against every host in a host_group, sequentially."""
+        group_id = planned["host_group_id"]
+        group = self._prov._state.get(group_id)
+        if group is None:
+            diags.add_error(
+                f"Host group '{group_id}' not found",
+                "Ensure the terrible_host_group resource exists and has been applied.",
+            )
+            return {}, False, {}
+
+        host_ids = group.get("host_ids") or []
+        if not host_ids:
+            diags.add_error(
+                f"Host group '{group_id}' has no hosts",
+                "Add at least one host ID to the group's host_ids list.",
+            )
+            return {}, False, {}
+
+        args_str = _build_args_str(planned)
+        results: dict = {}
+        any_changed = False
+
+        for hid in host_ids:
+            host = self._prov._state.get(hid)
+            if host is None:
+                diags.add_error(
+                    f"Host '{hid}' in group '{group_id}' not found",
+                    "Ensure the terrible_host resource exists and has been applied.",
+                )
+                return {}, False, {}
+            result = _run_module(
+                host, self.__class__._module_name, args_str,
+                timeout=planned.get("timeout"),
+                changed_when=planned.get("changed_when"),
+                failed_when=planned.get("failed_when"),
+                environment=planned.get("environment"),
+                tags=planned.get("tags"),
+                skip_tags=planned.get("skip_tags"),
+                async_seconds=planned.get("async_seconds"),
+                poll_interval=planned.get("poll_interval"),
+                vault_secrets=self._prov._vault_secrets,
+            )
+            if result.get("changed"):
+                any_changed = True
+            if result.get("failed") or result.get("unreachable"):
+                if not planned.get("ignore_errors"):
+                    diags.add_error("Ansible task failed", result.get("msg", "unknown error"))
+            results[hid] = result
+
+        # result is a host→result map; individual return attrs are not meaningful for groups
+        return results, any_changed, {}
+
     def create(self, ctx: CreateContext, planned: dict) -> Optional[dict]:
         result, changed, return_attrs = self._execute(ctx.diagnostics, planned)
         new_id = uuid.uuid4().hex
@@ -365,6 +436,9 @@ class TerribleTaskBase(Resource):
 
         if self.__class__._check_mode_support != "full":
             return stored  # input-hash idempotency only
+
+        if stored.get("host_group_id"):
+            return stored  # drift detection not supported for group targets
 
         result = self._execute_check(ctx.diagnostics, stored)
         if result is None:

--- a/tests/test_host_group.py
+++ b/tests/test_host_group.py
@@ -1,0 +1,82 @@
+"""Unit tests for TerribleHostGroup resource."""
+
+from unittest.mock import MagicMock
+
+from tf.iface import CreateContext, DeleteContext, ImportContext, ReadContext, UpdateContext
+from tf.utils import Diagnostics
+
+from terrible_provider.host_group import TerribleHostGroup
+
+
+def _ctx(klass):
+    return klass(Diagnostics(), "terrible_host_group")
+
+
+def _provider(state=None):
+    prov = MagicMock()
+    prov._state = state or {}
+    prov._save_state = MagicMock()
+    return prov
+
+
+class TestTerribleHostGroup:
+    def test_get_name(self):
+        assert TerribleHostGroup.get_name() == "host_group"
+
+    def test_schema_attrs(self):
+        names = {a.name for a in TerribleHostGroup.get_schema().attributes}
+        assert names == {"id", "host_ids"}
+
+    def test_create_assigns_id(self):
+        prov = _provider()
+        inst = TerribleHostGroup(prov)
+        state = inst.create(_ctx(CreateContext), {"host_ids": ["h1", "h2"]})
+        assert len(state["id"]) == 32
+        assert state["host_ids"] == ["h1", "h2"]
+
+    def test_create_saves_state(self):
+        prov = _provider()
+        inst = TerribleHostGroup(prov)
+        state = inst.create(_ctx(CreateContext), {"host_ids": ["h1"]})
+        assert state["id"] in prov._state
+        prov._save_state.assert_called_once()
+
+    def test_read_returns_stored(self):
+        prov = _provider({"g1": {"id": "g1", "host_ids": ["h1"]}})
+        inst = TerribleHostGroup(prov)
+        assert inst.read(_ctx(ReadContext), {"id": "g1"}) == {"id": "g1", "host_ids": ["h1"]}
+
+    def test_read_missing_returns_none(self):
+        prov = _provider()
+        inst = TerribleHostGroup(prov)
+        assert inst.read(_ctx(ReadContext), {"id": "nope"}) is None
+
+    def test_update_replaces_host_ids(self):
+        prov = _provider({"g1": {"id": "g1", "host_ids": ["h1"]}})
+        inst = TerribleHostGroup(prov)
+        result = inst.update(_ctx(UpdateContext), {"id": "g1"}, {"host_ids": ["h1", "h2"]})
+        assert result["host_ids"] == ["h1", "h2"]
+        assert result["id"] == "g1"
+        prov._save_state.assert_called_once()
+
+    def test_delete_removes_from_state(self):
+        prov = _provider({"g1": {"id": "g1", "host_ids": []}})
+        inst = TerribleHostGroup(prov)
+        inst.delete(_ctx(DeleteContext), {"id": "g1"})
+        assert "g1" not in prov._state
+        prov._save_state.assert_called_once()
+
+    def test_delete_missing_is_safe(self):
+        prov = _provider()
+        inst = TerribleHostGroup(prov)
+        inst.delete(_ctx(DeleteContext), {"id": None})  # no crash
+
+    def test_import_returns_state(self):
+        prov = _provider({"g1": {"id": "g1", "host_ids": ["h1"]}})
+        inst = TerribleHostGroup(prov)
+        assert inst.import_(_ctx(ImportContext), "g1") == {"id": "g1", "host_ids": ["h1"]}
+
+    def test_import_missing_returns_none(self):
+        prov = _provider()
+        inst = TerribleHostGroup(prov)
+        assert inst.import_(_ctx(ImportContext), "gone") is None

--- a/tests/test_task_base.py
+++ b/tests/test_task_base.py
@@ -1134,3 +1134,143 @@ class TestSetupHostInventoryWinRM:
         hobj = self._make_host()
         _setup_host_inventory(hobj, {"host": "linux.example.com", "connection": "ssh"})
         assert "ansible_ssh_extra_args" in hobj.vars
+
+
+# ---------------------------------------------------------------------------
+# host_group_id support
+# ---------------------------------------------------------------------------
+
+class TestHostGroupExecution:
+    _RESULT = {"changed": False, "ping": "pong"}
+
+    def _group(self, host_ids):
+        return {"id": "g1", "host_ids": host_ids}
+
+    def test_both_host_id_and_group_id_adds_error(self):
+        klass = _make_class()
+        prov = _provider(state={"h1": _host(), "g1": self._group(["h1"])})
+        inst = klass(prov)
+        diags = Diagnostics()
+        inst._execute(diags, {"host_id": "h1", "host_group_id": "g1"})
+        assert diags.has_errors()
+
+    def test_neither_host_id_nor_group_id_adds_error(self):
+        klass = _make_class()
+        prov = _provider(state={"h1": _host()})
+        inst = klass(prov)
+        diags = Diagnostics()
+        inst._execute(diags, {})
+        assert diags.has_errors()
+
+    def test_group_not_found_adds_error(self):
+        klass = _make_class()
+        prov = _provider()
+        inst = klass(prov)
+        diags = Diagnostics()
+        inst._execute(diags, {"host_group_id": "missing"})
+        assert diags.has_errors()
+
+    def test_empty_group_adds_error(self):
+        klass = _make_class()
+        prov = _provider(state={"g1": self._group([])})
+        inst = klass(prov)
+        diags = Diagnostics()
+        inst._execute(diags, {"host_group_id": "g1"})
+        assert diags.has_errors()
+
+    def test_host_in_group_not_found_adds_error(self):
+        klass = _make_class()
+        prov = _provider(state={"g1": self._group(["missing"])})
+        inst = klass(prov)
+        diags = Diagnostics()
+        inst._execute(diags, {"host_group_id": "g1"})
+        assert diags.has_errors()
+
+    def test_group_result_is_map_of_host_to_result(self):
+        klass = _make_class()
+        h1 = _host()
+        h2 = {"host": "10.0.0.2", "connection": "local"}
+        prov = _provider(state={"h1": h1, "h2": h2, "g1": self._group(["h1", "h2"])})
+        inst = klass(prov)
+        with patch("terrible_provider.task_base._run_module", return_value=self._RESULT):
+            result, changed, return_attrs = inst._execute(Diagnostics(), {"host_group_id": "g1"})
+        assert "h1" in result
+        assert "h2" in result
+        assert result["h1"] == self._RESULT
+        assert result["h2"] == self._RESULT
+
+    def test_group_changed_true_if_any_host_changed(self):
+        klass = _make_class()
+        h1 = _host()
+        h2 = {"host": "10.0.0.2", "connection": "local"}
+        prov = _provider(state={"h1": h1, "h2": h2, "g1": self._group(["h1", "h2"])})
+        inst = klass(prov)
+        side_effects = [{"changed": False}, {"changed": True}]
+        with patch("terrible_provider.task_base._run_module", side_effect=side_effects):
+            _, changed, _ = inst._execute(Diagnostics(), {"host_group_id": "g1"})
+        assert changed is True
+
+    def test_group_changed_false_if_no_host_changed(self):
+        klass = _make_class()
+        h1 = _host()
+        h2 = {"host": "10.0.0.2", "connection": "local"}
+        prov = _provider(state={"h1": h1, "h2": h2, "g1": self._group(["h1", "h2"])})
+        inst = klass(prov)
+        with patch("terrible_provider.task_base._run_module", return_value={"changed": False}):
+            _, changed, _ = inst._execute(Diagnostics(), {"host_group_id": "g1"})
+        assert changed is False
+
+    def test_group_failure_adds_error(self):
+        klass = _make_class()
+        prov = _provider(state={"h1": _host(), "g1": self._group(["h1"])})
+        inst = klass(prov)
+        diags = Diagnostics()
+        with patch("terrible_provider.task_base._run_module", return_value={"failed": True, "msg": "boom"}):
+            inst._execute(diags, {"host_group_id": "g1"})
+        assert diags.has_errors()
+
+    def test_group_failure_suppressed_with_ignore_errors(self):
+        klass = _make_class()
+        prov = _provider(state={"h1": _host(), "g1": self._group(["h1"])})
+        inst = klass(prov)
+        diags = Diagnostics()
+        with patch("terrible_provider.task_base._run_module", return_value={"failed": True, "msg": "boom"}):
+            inst._execute(diags, {"host_group_id": "g1", "ignore_errors": True})
+        assert not diags.has_errors()
+
+    def test_create_with_group_stores_result_map(self):
+        klass = _make_class()
+        h1 = _host()
+        prov = _provider(state={"h1": h1, "g1": self._group(["h1"])})
+        inst = klass(prov)
+        with patch("terrible_provider.task_base._run_module", return_value=self._RESULT):
+            state = inst.create(_ctx(CreateContext), {"host_group_id": "g1"})
+        assert isinstance(state["result"], dict)
+        assert "h1" in state["result"]
+
+    def test_read_with_group_skips_drift_detection(self):
+        klass = _make_class(check_mode="full")
+        stored = {"id": "rid", "host_group_id": "g1", "result": {}, "changed": False}
+        prov = _provider(state={"rid": stored})
+        inst = klass(prov)
+        with patch("terrible_provider.task_base._run_module") as mock_run:
+            result = inst.read(_ctx(ReadContext), {"id": "rid"})
+        mock_run.assert_not_called()
+        assert result == stored
+
+    def test_framework_schema_has_host_group_id(self):
+        from terrible_provider.discovery import _FRAMEWORK_ATTRS
+        names = {a.name for a in _FRAMEWORK_ATTRS}
+        assert "host_group_id" in names
+
+    def test_host_id_is_optional_in_schema(self):
+        from terrible_provider.discovery import _FRAMEWORK_ATTRS
+        attrs = {a.name: a for a in _FRAMEWORK_ATTRS}
+        assert attrs["host_id"].optional
+        assert not attrs["host_id"].required
+
+    def test_build_args_skips_host_group_id(self):
+        from terrible_provider.task_base import _build_args_str
+        result = _build_args_str({"host_group_id": "g1", "path": "/tmp/f"})
+        import json
+        assert json.loads(result) == {"path": "/tmp/f"}


### PR DESCRIPTION
Closes #14.

## Summary
- New `terrible_host_group` resource aggregates a list of `terrible_host` IDs into a named group
- Task resources gain an optional `host_group_id` attribute, mutually exclusive with `host_id`
- When a group is targeted, the module runs against each host sequentially; `result` is a map of `host_id → result`; `changed` is true if any host reported a change
- Drift detection (check mode) is skipped for group-targeted resources — returns stored state
- Full 100% unit test coverage; all integration tests pass

## Test plan
- [x] `test_host_group.py` — full CRUD coverage for `TerribleHostGroup`
- [x] `test_task_base.py` — mutual exclusivity validation, group not found, empty group, host in group not found, result aggregation, changed aggregation, ignore_errors, create/read with group, schema checks
- [x] Pre-commit hook: unit + integration tests green