### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "terrible"
-version = "0.3.0"
+version = "0.4.0"
 description = "Terraform provider that exposes Ansible modules as Terraform-managed resources"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Version bump for the v0.4.0 release.

## v0.4.0 changelog
- WinRM support on `terrible_host`
- Ansible Vault integration (`terrible_vault` data source + provider `vault_password`/`vault_password_file`)
- `delegate_to_id` on task resources
- CI integration tests