### PR TITLE
chore: update uv.lock for 0.4.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -722,7 +722,7 @@ wheels = [
 
 [[package]]
 name = "terrible"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
Lock file wasn't updated alongside pyproject.toml in the version bump commit.