### PR TITLE
feat: PyInstaller binary, release workflow, and updated release.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  # ── Stage 1: validate on all platforms ────────────────────────────────────
+  validate:
+    name: validate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true   # one failure blocks the release
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - os: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+          - os: macos-13
+            goos: darwin
+            goarch: amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+          - os: windows-latest
+            goos: windows
+            goarch: amd64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install OpenTofu
+        if: matrix.goos != 'windows'
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: false
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Unit tests (100% coverage required)
+        run: uv run pytest tests/ --ignore=tests/integration -q
+
+      - name: Integration tests
+        if: matrix.goos != 'windows'
+        run: make integration-test
+
+      - name: Build PyInstaller binary
+        run: uv run pyinstaller terrible.spec --distpath dist --workpath build/pyinstaller --noconfirm
+
+      - name: Determine binary name and zip path
+        id: names
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          BINARY="terraform-provider-terrible_v${VERSION}"
+          if [[ "${{ matrix.goos }}" == "windows" ]]; then
+            BINARY="${BINARY}.exe"
+          fi
+          ZIP="terraform-provider-terrible_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.zip"
+          echo "binary=${BINARY}" >> "$GITHUB_OUTPUT"
+          echo "zip=${ZIP}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Rename binary
+        shell: bash
+        run: |
+          DIST="dist/terraform-provider-terrible"
+          if [[ "${{ matrix.goos }}" == "windows" ]]; then
+            DIST="${DIST}.exe"
+          fi
+          mv "$DIST" "dist/${{ steps.names.outputs.binary }}"
+
+      - name: Zip binary
+        shell: bash
+        run: |
+          cd dist
+          if [[ "${{ matrix.goos }}" == "windows" ]]; then
+            7z a "../${{ steps.names.outputs.zip }}" "${{ steps.names.outputs.binary }}"
+          else
+            zip "../${{ steps.names.outputs.zip }}" "${{ steps.names.outputs.binary }}"
+          fi
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.names.outputs.zip }}
+          path: ${{ steps.names.outputs.zip }}
+          if-no-files-found: error
+
+  # ── Stage 2: publish (only if ALL validate jobs pass) ─────────────────────
+  publish:
+    name: publish
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all platform zips
+        uses: actions/download-artifact@v4
+        with:
+          path: zips
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd zips
+          sha256sum *.zip > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+        env:
+          GPG_TTY: /dev/null
+
+      - name: Sign SHA256SUMS
+        run: |
+          cd zips
+          gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" \
+              --pinentry-mode loopback \
+              --detach-sign --armor --output SHA256SUMS.sig SHA256SUMS
+
+      - name: Upload release assets
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" zips/*.zip zips/SHA256SUMS zips/SHA256SUMS.sig
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!terrible.spec
 
 # Installer logs
 pip-log.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,14 +149,15 @@ Before cutting any release:
 4. Working tree is clean (`git status` shows nothing).
 5. `pyproject.toml` version matches the release version.
 
-### Cutting a release (pre-0.5.0 — no registry publishing yet)
+### Cutting a release
 
 Use `scripts/release.sh` or the `make release` target. Never tag or create
 GitHub releases manually — the script enforces the checklist, runs tests,
-creates the annotated tag, pushes it, and creates the GitHub release.
+creates the annotated tag, pushes it, creates the GitHub release, then watches
+the Actions workflow.
 
 ```bash
-scripts/release.sh 0.4.0 <<'EOF'
+scripts/release.sh 0.5.0 <<'EOF'
 Short title line (becomes the release title)
 
 ## New features
@@ -167,18 +168,11 @@ Short title line (becomes the release title)
 EOF
 
 # Equivalent:
-make release VERSION=0.4.0   # reads notes from stdin
+make release VERSION=0.5.0   # reads notes from stdin
 ```
 
-Release notes must be non-empty and follow the format above. The first
-non-empty line becomes the release title on GitHub.
-
-After pushing, verify CI passes:
-
-```bash
-gh run list --limit 3
-gh run watch <run-id> --exit-status
-```
+Release notes must be non-empty. The first non-empty line becomes the release
+title on GitHub.
 
 ### Cutting a release (0.5.0+ — Terraform Registry publishing)
 
@@ -188,13 +182,13 @@ The `release.yml` workflow enforces this with two sequential stages:
 
 **Stage 1 — validate (all must pass before stage 2 runs):**
 - Unit tests (`uv run pytest -q`, 100% coverage) on all 5 platform runners
-- Integration tests on all 5 platform runners
+- Integration tests on all 5 platform runners (skipped on Windows — Ansible doesn't support Windows control nodes)
 - PyInstaller binary builds on all 5 platform runners
 
 **Stage 2 — publish (runs only if stage 1 is fully green):**
 - Merge all platform zips
 - Generate `SHA256SUMS`
-- GPG-sign (`SHA256SUMS.sig`)
+- GPG-sign (`SHA256SUMS.sig`) using `GPG_PRIVATE_KEY` + `GPG_PASSPHRASE` secrets
 - Upload all assets to GitHub release
 - registry.terraform.io auto-detects within ~10 minutes
 
@@ -203,21 +197,48 @@ failure — blocks the entire release. No partial publishing.
 
 To cut a release:
 
-1. Run pre-release checklist above.
-2. Push the tag:
-   ```bash
-   git tag -a v0.5.0 -m "v0.5.0 — <title>"
-   git push origin v0.5.0
-   ```
-3. Monitor the workflow:
-   ```bash
-   gh run watch --exit-status
-   ```
-4. If all green, the release publishes automatically. If anything fails,
-   delete the tag, fix the issue, and re-tag.
+```bash
+scripts/release.sh 0.5.0 <<'EOF'
+Short title line (becomes the release title)
 
-`scripts/release.sh` (issue #21) will wrap steps 2–3 and surface failures
-clearly.
+## New features
+- bullet points here
+EOF
+```
+
+The script runs tests, tags, pushes, creates the GitHub release, then watches
+the Actions workflow and reports success or failure. If the workflow fails,
+the script prints instructions to roll back the tag and release.
+
+### GPG key setup (one-time)
+
+The Terraform Registry requires releases to be GPG-signed. Required secrets
+in GitHub → Settings → Secrets and variables → Actions:
+
+- `GPG_PRIVATE_KEY` — ASCII-armored private key (`gpg --armor --export-secret-keys KEY_ID`)
+- `GPG_PASSPHRASE` — passphrase for the key
+
+To generate a new key:
+```bash
+gpg --batch --gen-key <<EOF
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: RSA
+Subkey-Length: 4096
+Name-Real: terraform-provider-terrible releases
+Name-Email: releases@example.com
+Expire-Date: 0
+EOF
+```
+
+### GPG key rotation
+
+1. Generate a new key (see above).
+2. Export and update `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` in GitHub Secrets.
+3. Register the new public key on registry.terraform.io (Settings → GPG Keys).
+4. Leave the old key registered — the registry validates historical releases against it.
+5. Delete the old key from the registry only after all old releases are superseded.
 
 ### Milestones and issues
 
@@ -227,7 +248,7 @@ issues.
 
 To check:
 ```bash
-gh api repos/rhencke/terrible/milestones --jq '.[] | {title, open_issues, closed_issues}'
+gh api repos/rhencke/terraform-provider-terrible/milestones --jq '.[] | {title, open_issues, closed_issues}'
 ```
 
 ## Pre-commit Hook

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 	@echo "  example-init           - run 'tofu init' in the example project"
 	@echo "  example-apply          - run 'tofu apply' in the example project (interactive)"
 	@echo "  example-fresh          - reinstall provider, wipe state, and auto-apply the example"
-	@echo "  build-binary           - build a standalone pex binary (terraform-provider-terrible)"
+	@echo "  build-binary           - build a standalone PyInstaller binary (terraform-provider-terrible)"
 	@echo "  release VERSION=x.y.z  - run tests, tag, push, and create GitHub release (notes from stdin)"
 
 test:
@@ -42,11 +42,8 @@ example-fresh: install-provider
 	cd examples/terraform_provider && tofu apply -auto-approve
 
 build-binary:
-	uv export --format requirements-txt --no-dev --no-hashes | grep -v '^-e' > /tmp/terrible-requirements.txt
-	uv run pex -r /tmp/terrible-requirements.txt . \
-	  -o terraform-provider-terrible \
-	  -m terrible_provider.cli:main
-	@echo "Binary built: ./terraform-provider-terrible"
+	uv run pyinstaller terrible.spec --distpath dist --workpath build/pyinstaller --noconfirm
+	@echo "Binary built: ./dist/terraform-provider-terrible"
 
 release:
 	@test -n "$(VERSION)" || (echo "Usage: make release VERSION=x.y.z"; exit 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pytest-timeout>=2.3.0",
     "pex>=2.20.0",
     "pytest-cov>=7.0.0",
+    "pyinstaller>=6.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Release script for terrible.
+# Release script for terraform-provider-terrible.
 #
 # Usage:
 #   scripts/release.sh VERSION <<'EOF'
@@ -8,10 +8,11 @@
 #
 # The script will:
 #   1. Verify the working tree is clean
-#   2. Run the full test suite
-#   3. Create an annotated git tag vVERSION
-#   4. Push the tag to origin
-#   5. Create a GitHub release with the supplied notes
+#   2. Verify pyproject.toml version matches VERSION
+#   3. Run the full test suite
+#   4. Create an annotated git tag vVERSION and push it
+#   5. Create the GitHub release (assets uploaded by the Actions release workflow)
+#   6. Wait for and report the release workflow result
 #
 # Requirements: git, uv, gh (GitHub CLI authenticated)
 
@@ -23,6 +24,14 @@ TAG="v${VERSION}"
 # Verify clean working tree
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "ERROR: working tree is dirty — commit all changes before releasing." >&2
+    exit 1
+fi
+
+# Verify pyproject.toml version matches
+TOML_VERSION="$(grep '^version' pyproject.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')"
+if [[ "${TOML_VERSION}" != "${VERSION}" ]]; then
+    echo "ERROR: pyproject.toml version is '${TOML_VERSION}', expected '${VERSION}'." >&2
+    echo "       Bump the version in pyproject.toml (and uv.lock) before releasing." >&2
     exit 1
 fi
 
@@ -46,10 +55,35 @@ uv run pytest -q
 git tag -a "${TAG}" -m "${TAG} — ${TITLE}"$'\n\n'"${NOTES}"
 git push origin "${TAG}"
 
-# Create GitHub release
+# Create the GitHub release (placeholder — assets will be attached by the workflow)
 gh release create "${TAG}" \
     --title "${TAG} — ${TITLE}" \
-    --notes "${NOTES}"
+    --notes "${NOTES}" \
+    --draft=false
 
 echo ""
-echo "Released ${TAG}: $(gh release view "${TAG}" --json url -q '.url')"
+echo "Tag pushed. Waiting for release workflow..."
+echo ""
+
+# Find and watch the workflow run triggered by this tag
+sleep 5  # give GitHub a moment to register the run
+RUN_ID="$(gh run list --workflow=release.yml --limit=1 --json databaseId --jq '.[0].databaseId')"
+
+if [[ -z "${RUN_ID}" ]]; then
+    echo "WARNING: could not find release workflow run. Check:"
+    echo "  gh run list --workflow=release.yml"
+    exit 1
+fi
+
+echo "Watching run ${RUN_ID}..."
+if gh run watch "${RUN_ID}" --exit-status; then
+    echo ""
+    echo "Released ${TAG}: $(gh release view "${TAG}" --json url -q '.url')"
+else
+    echo ""
+    echo "ERROR: release workflow failed. Assets were NOT published." >&2
+    echo "Fix the issue, delete the tag and release, then re-release:" >&2
+    echo "  git tag -d ${TAG} && git push origin :${TAG}" >&2
+    echo "  gh release delete ${TAG} --yes" >&2
+    exit 1
+fi

--- a/terrible.spec
+++ b/terrible.spec
@@ -1,0 +1,93 @@
+# PyInstaller spec for terraform-provider-terrible
+# Bundles CPython + Ansible + all deps into a single native executable.
+#
+# Build:
+#   pyinstaller terrible.spec
+# or via make:
+#   make build-binary
+#
+# Output: dist/terraform-provider-terrible
+
+from PyInstaller.utils.hooks import collect_all, collect_data_files, collect_submodules
+
+# Collect entire packages that use dynamic loading
+ansible_datas, ansible_binaries, ansible_hiddenimports = collect_all('ansible')
+tf_datas, tf_binaries, tf_hiddenimports = collect_all('tf')
+grpc_datas, grpc_binaries, grpc_hiddenimports = collect_all('grpc')
+grpc_tools_datas, grpc_tools_binaries, grpc_tools_hiddenimports = collect_all('grpc._channel')
+
+# Jinja2 extensions loaded by Ansible at runtime
+jinja2_datas, jinja2_binaries, jinja2_hiddenimports = collect_all('jinja2')
+
+# cryptography (used by Ansible Vault)
+crypto_datas, crypto_binaries, crypto_hiddenimports = collect_all('cryptography')
+
+a = Analysis(
+    ['terrible_provider/cli.py'],
+    pathex=['.'],
+    binaries=ansible_binaries + tf_binaries + grpc_binaries + crypto_binaries,
+    datas=(
+        ansible_datas
+        + tf_datas
+        + grpc_datas
+        + jinja2_datas
+        + crypto_datas
+        + collect_data_files('ansible_collections', include_py_files=True)
+    ),
+    hiddenimports=(
+        ansible_hiddenimports
+        + tf_hiddenimports
+        + grpc_hiddenimports
+        + jinja2_hiddenimports
+        + crypto_hiddenimports
+        + collect_submodules('ansible')
+        + collect_submodules('ansible_collections')
+        + [
+            # Ansible internals loaded via string at runtime
+            'ansible.executor.task_queue_manager',
+            'ansible.plugins.loader',
+            'ansible.plugins.callback',
+            'ansible.plugins.connection.ssh',
+            'ansible.plugins.connection.local',
+            'ansible.plugins.connection.docker',
+            'ansible.plugins.connection.winrm',
+            'ansible.plugins.become.sudo',
+            'ansible.plugins.become.su',
+            'ansible.utils.collection_loader._collection_finder',
+            # gRPC internals
+            'grpc._cython.cygrpc',
+            # pkg_resources / importlib.metadata used by Ansible
+            'pkg_resources',
+            'importlib.metadata',
+            'importlib.resources',
+        ]
+    ),
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='terraform-provider-terrible',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    onefile=True,
+)

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "ansible"
 version = "13.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -387,6 +396,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +524,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "pex"
 version = "2.91.2"
 source = { registry = "https://pypi.org/simple" }
@@ -551,6 +581,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/63/fd62472b6371d89dc138d40c36d87a50dc2de18a035803bbdc376b4ffac4/pyinstaller-6.19.0.tar.gz", hash = "sha256:ec73aeb8bd9b7f2f1240d328a4542e90b3c6e6fbc106014778431c616592a865", size = 4036072, upload-time = "2026-02-14T18:06:28.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/eb/23374721fecfa72677e79800921cb6aceefa6ba48574dc404f3f6c6c3be7/pyinstaller-6.19.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:4190e76b74f0c4b5c5f11ac360928cd2e36ec8e3194d437bf6b8648c7bc0c134", size = 1040563, upload-time = "2026-02-14T18:05:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7e/dfd724b0b533f5aaec0ee5df406fe2319987ed6964480a706f85478b12ea/pyinstaller-6.19.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8bd68abd812d8a6ba33b9f1810e91fee0f325969733721b78151f0065319ca11", size = 735477, upload-time = "2026-02-14T18:05:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c9/ee3a4101c31f26344e66896c73c1fd6ed8282bf871473365b7f8674af406/pyinstaller-6.19.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1ec54ef967996ca61dacba676227e2b23219878ccce5ee9d6f3aada7b8ed8abf", size = 747143, upload-time = "2026-02-14T18:05:31.488Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0a/fc77e9f861be8cf300ac37155f59cc92aff99b29f2ddd78546f563a5b5a6/pyinstaller-6.19.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4ab2bb52e58448e14ddf9450601bdedd66800465043501c1d8f1cab87b60b122", size = 744849, upload-time = "2026-02-14T18:05:35.492Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e3/6872e020ee758afe0b821663858492c10745608b07150e5e2c824a5b3e1c/pyinstaller-6.19.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:da6d5c6391ccefe73554b9fa29b86001c8e378e0f20c2a4004f836ba537eff63", size = 741590, upload-time = "2026-02-14T18:05:39.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/b8db5f1a4b0fb228175f2ea0aa33f949adcc097fbe981cc524f9faf85777/pyinstaller-6.19.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a0fc5f6b3c55aa54353f0c74ffa59b1115433c1850c6f655d62b461a2ed6cbbe", size = 741448, upload-time = "2026-02-14T18:05:45.636Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4d/63b0600f2694e9141b83129fbc1c488ec84d5a0770b1448ec154dcd0fee9/pyinstaller-6.19.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:e649ba6bd1b0b89b210ad92adb5fbdc8a42dd2c5ca4f72ef3a0bfec83a424b83", size = 740613, upload-time = "2026-02-14T18:05:49.726Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d4/e812ad36178093a0e9fd4b8127577748dd85b0cb71de912229dca21fd741/pyinstaller-6.19.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:481a909c8e60c8692fc60fcb1344d984b44b943f8bc9682f2fcdae305ad297e6", size = 740350, upload-time = "2026-02-14T18:05:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/52/03/b2c2ee41fb8e10fd2a45d21f5ec2ef25852cfb978dbf762972eed59e3d63/pyinstaller-6.19.0-py3-none-win32.whl", hash = "sha256:3c5c251054fe4cfaa04c34a363dcfbf811545438cb7198304cd444756bc2edd2", size = 1324317, upload-time = "2026-02-14T18:06:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d3/6d5e62b8270e2b53a6065e281b3a7785079b00e9019c8019952828dd1669/pyinstaller-6.19.0-py3-none-win_amd64.whl", hash = "sha256:b5bb6536c6560330d364d91522250f254b107cf69129d9cbcd0e6727c570be33", size = 1384894, upload-time = "2026-02-14T18:06:06.425Z" },
+    { url = "https://files.pythonhosted.org/packages/81/65/458cd523308a101a22fd2742893405030cc24994cc74b1b767cecf137160/pyinstaller-6.19.0-py3-none-win_arm64.whl", hash = "sha256:c2d5a539b0bfe6159d5522c8c70e1c0e487f22c2badae0f97d45246223b798ea", size = 1325374, upload-time = "2026-02-14T18:06:12.804Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/17/716326f6ba18d0663f7995ae369c23e50efebc22fbb054e9710a45688f61/pyinstaller_hooks_contrib-2026.3.tar.gz", hash = "sha256:800d3a198a49a6cd0de2d7fb795005fdca7a0222ed9cb47c0691abd1c27b9310", size = 172323, upload-time = "2026-03-09T22:44:06.345Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/19/781352446af28755f16ce52b2d97f7a6f2d7974ac34c00ca5cd8c40c9098/pyinstaller_hooks_contrib-2026.3-py3-none-any.whl", hash = "sha256:5ecd1068ad262afecadf07556279d2be52ca93a88b049fae17f1a2eb2969254a", size = 454625, upload-time = "2026-03-09T22:44:04.717Z" },
 ]
 
 [[package]]
@@ -606,6 +677,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -707,6 +787,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "sspilib"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -737,6 +826,7 @@ winrm = [
 [package.dev-dependencies]
 dev = [
     { name = "pex" },
+    { name = "pyinstaller" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
@@ -753,6 +843,7 @@ provides-extras = ["winrm"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pex", specifier = ">=2.20.0" },
+    { name = "pyinstaller", specifier = ">=6.0.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-timeout", specifier = ">=2.3.0" },


### PR DESCRIPTION
## Summary

- **#19** — `terrible.spec` PyInstaller spec; `make build-binary` now produces a single-file native executable via PyInstaller instead of pex
- **#20** — `.github/workflows/release.yml`: two-stage release gate across 5 platforms (linux_amd64, linux_arm64, darwin_amd64, darwin_arm64, windows_amd64). Stage 1 runs unit tests + integration tests + binary build on each; stage 2 generates `SHA256SUMS`, GPG-signs, and uploads all assets. One platform failure blocks the whole release.
- **#21** — `scripts/release.sh` updated to push the tag, create the GitHub release shell, then watch and report the Actions workflow
- **#23** — integration tests run on all non-Windows platforms in the release matrix (Ansible doesn't support Windows as a control node)
- CLAUDE.md updated with GPG key setup and rotation procedure

## Still needed before v0.5.0

- **#17** — rename repo to `terraform-provider-terrible` (requires GitHub Settings → General, token scope blocks API)
- **#18** — generate GPG key, add `GPG_PRIVATE_KEY` + `GPG_PASSPHRASE` to GitHub Secrets, register public key on registry.terraform.io
- **#22** — register provider on registry.terraform.io after #17 and #18 are done

## Test plan

- [ ] CI passes on this PR (unit + integration on ubuntu-latest)
- [ ] After merge: push a test tag and verify the release workflow runs all 5 matrix jobs and reaches the publish stage