### PR TITLE
fix: create GitHub release in publish job if not already created by release.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Create GitHub release if it does not exist
+        run: |
+          if ! gh release view "${GITHUB_REF_NAME}" &>/dev/null; then
+            NOTES="$(git tag -l --format='%(contents)' "${GITHUB_REF_NAME}")"
+            TITLE="$(echo "${NOTES}" | awk 'NF{print; exit}')"
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${TITLE:-${GITHUB_REF_NAME}}" \
+              --notes "${NOTES:-${GITHUB_REF_NAME}}"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Download all platform zips
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
When a tag is pushed directly (e.g. RC tags) without going through `release.sh`, the publish job failed with `release not found` because no GitHub release existed yet.\n\nFix: publish job creates the release if it doesn't exist, using the tag annotation as title and notes. If `release.sh` already created it, the step is a no-op.