### PR TITLE
fix: don't pre-create GitHub release in release.sh; bump to 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "terrible"
-version = "0.5.0"
+version = "0.5.1"
 description = "Terraform provider that exposes Ansible modules as Terraform-managed resources"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -52,14 +52,11 @@ echo "Running test suite..."
 uv run pytest -q
 
 # Create and push the annotated tag
+# The release workflow's publish job creates the GitHub release and uploads assets.
+# Do NOT create the release here — creating it before assets are uploaded makes it
+# immutable and the subsequent `gh release upload` call fails with HTTP 422.
 git tag -a "${TAG}" -m "${TAG} — ${TITLE}"$'\n\n'"${NOTES}"
 git push origin "${TAG}"
-
-# Create the GitHub release (placeholder — assets will be attached by the workflow)
-gh release create "${TAG}" \
-    --title "${TAG} — ${TITLE}" \
-    --notes "${NOTES}" \
-    --draft=false
 
 echo ""
 echo "Tag pushed. Waiting for release workflow..."

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "terrible"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
## Summary
- Removes premature `gh release create` call from `release.sh` — creating the release before assets are uploaded makes it immutable, causing `HTTP 422: Cannot upload assets to an immutable release` in the publish job
- The workflow's publish job already handles release creation from the tag annotation if it doesn't exist
- Bumps version to 0.5.1 (v0.5.0 tag was lost due to this bug)

## Test plan
- [ ] CI passes
- [ ] After merge: cut v0.5.1 via `scripts/release.sh 0.5.1`