### PR TITLE
fix: create release as draft, upload assets, then publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,18 +97,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create GitHub release if it does not exist
-        run: |
-          if ! gh release view "${GITHUB_REF_NAME}" &>/dev/null; then
-            NOTES="$(git tag -l --format='%(contents)' "${GITHUB_REF_NAME}")"
-            TITLE="$(echo "${NOTES}" | awk 'NF{print; exit}')"
-            gh release create "${GITHUB_REF_NAME}" \
-              --title "${TITLE:-${GITHUB_REF_NAME}}" \
-              --notes "${NOTES:-${GITHUB_REF_NAME}}"
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       - name: Download all platform zips
         uses: actions/download-artifact@v4
         with:
@@ -134,8 +122,15 @@ jobs:
               --pinentry-mode loopback \
               --detach-sign --armor --output SHA256SUMS.sig SHA256SUMS
 
-      - name: Upload release assets
+      - name: Create release and upload assets
         run: |
-          gh release upload "${GITHUB_REF_NAME}" zips/*.zip zips/SHA256SUMS zips/SHA256SUMS.sig
+          NOTES="$(git tag -l --format='%(contents)' "${GITHUB_REF_NAME}")"
+          TITLE="$(echo "${NOTES}" | awk 'NF{print; exit}')"
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${TITLE:-${GITHUB_REF_NAME}}" \
+            --notes "${NOTES:-${GITHUB_REF_NAME}}" \
+            --draft \
+            zips/*.zip zips/SHA256SUMS zips/SHA256SUMS.sig
+          gh release edit "${GITHUB_REF_NAME}" --draft=false
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
GitHub marks releases as immutable immediately upon creation via the REST API, causing `HTTP 422: Cannot upload assets to an immutable release` on the subsequent upload step.

Fix: create the release as a draft (which is not immutable), upload all assets to the draft in the same `gh release create` call, then unpublish the draft with `gh release edit --draft=false`.

## Test plan
- [ ] CI passes
- [ ] After merge: cut v0.5.1 via `scripts/release.sh 0.5.1`