### PR TITLE
chore: bump to 0.5.2, fix release upload permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,4 +173,5 @@ Runs:
 - Always close GitHub issues when implementing their features.
 - Always resolve PR review threads (via GraphQL `resolveReviewThread` mutation) as you address them — replying is not enough. Don't merge with unresolved conversations.
 - Always tag releases with release notes — never leave notes empty.
+- **Never delete tags or releases.** Tags and releases are immutable once pushed. Deleting them triggers GitHub tag-protection rules that permanently block recreation of the same ref name. If a release workflow fails, fix the workflow and cut a new patch version instead.
 - Before the first commit in a session, check if `.git/hooks/pre-commit` exists. If not, run `scripts/install-hooks.sh`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "terrible"
-version = "0.5.1"
+version = "0.5.2"
 description = "Terraform provider that exposes Ansible modules as Terraform-managed resources"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "terrible"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
## Summary
- Add `actions: read` permission to publish job — required for `actions/download-artifact@v4` cross-job artifact downloads
- Document in CLAUDE.md: never delete tags or releases (GitHub permanently blocks recreation of ref names used by prior releases)
- Bump version to 0.5.2

Note: the draft-create-upload-publish approach (PR #39) is already on main. This PR adds the missing `actions: read` permission and bumps the version.