### PR TITLE
feat: delete draft release if binary validation fails (#45)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,3 +221,22 @@ jobs:
         run: gh release edit "${GITHUB_REF_NAME}" --draft=false
         env:
           GH_TOKEN: ${{ github.token }}
+
+  # ── Cleanup: delete draft if binary validation failed ─────────────────────
+  # Draft releases are invisible to the registry, so it is safe to delete them.
+  # The tag remains; cut a new patch version to retry.
+  cleanup_on_failure:
+    name: cleanup on failure
+    needs: validate_binary
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Delete draft release
+        run: |
+          echo "Binary validation failed — deleting draft release ${GITHUB_REF_NAME}."
+          gh release delete "${GITHUB_REF_NAME}" --yes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Closes #45.

## Summary
Adds a `cleanup_on_failure` job that runs when `validate_binary` fails:
- Deletes the draft release (safe — drafts are invisible to the Terraform Registry)
- The tag remains on remote; cut a new patch version to retry

## Why delete the draft
If binary validation fails there's nothing worth keeping — the release was never visible to users or the registry. Cleaning it up avoids stale draft releases accumulating in the GitHub UI.

## Test plan
- [ ] CI passes
- [ ] On next release, if a binary validation job fails, confirm the draft is deleted and workflow fails