### PR TITLE
chore: update merge policy to auto-merge once CI passes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Runs:
 - Always check CI after every push (`gh run list --limit 3`) and report the result.
 - Always close GitHub issues when implementing their features.
 - Always resolve PR review threads (via GraphQL `resolveReviewThread` mutation) as you address them — replying is not enough. Don't merge with unresolved conversations.
-- Before merging a PR, explicitly check for review comments (`gh api repos/rhencke/terraform-provider-terrible/pulls/{N}/comments` and `.../reviews`) and wait for the user to approve merging. Never use `--auto` on `gh pr merge` — always wait, check, then merge explicitly.
+- Merge PRs automatically once CI passes and there are no unresolved review comments. No need to wait for explicit user approval to merge.
 - Always tag releases with release notes — never leave notes empty.
 - **Never delete tags or releases.** Tags and releases are immutable once pushed. Deleting them triggers GitHub tag-protection rules that permanently block recreation of the same ref name. If a release workflow fails, fix the workflow and cut a new patch version instead.
 - Before the first commit in a session, check if `.git/hooks/pre-commit` exists. If not, run `scripts/install-hooks.sh`.


### PR DESCRIPTION
Update CLAUDE.md: merge automatically when CI is green and no unresolved review comments.