### PR TITLE
chore: bump to 0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "terrible"
-version = "0.6.0"
+version = "0.6.1"
 description = "Terraform provider that exposes Ansible modules as Terraform-managed resources"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "terrible"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
Version bump — v0.6.0 tag predates the draft-release download fix.