### PR TITLE
fix: add contents:write permission to validate_binary job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,8 @@ jobs:
     name: validate binary (${{ matrix.os }})
     needs: [draft]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
The `validate_binary` job was getting HTTP 403 when calling `gh api .../releases/.../assets` — draft release assets require `contents: write`. Added explicit permission.