### PR TITLE
chore: bump to 0.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "terrible"
-version = "0.6.3"
+version = "0.6.4"
 description = "Terraform provider that exposes Ansible modules as Terraform-managed resources"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "terrible"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
Bump version to 0.6.4 for release.

## Changes in 0.6.4
- Add `actions/checkout@v4` to publish job so `gh release edit` has git context (fixes publish automation)
- Add job progress output to `release.sh` stderr while watching the release workflow