### PR TITLE
docs: fix resource naming — terrible_* not terrible_ansible_builtin_*

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,11 @@
 
 Resource types:
 - `terrible_host` — target host (SSH, WinRM, local, docker, etc.)
-- `terrible_ansible_builtin_*` — dynamically-generated task resources, one per Ansible module
-- `terrible_playbook` — runs an Ansible playbook file
-- `terrible_role` — runs an Ansible role
+- `terrible_*` — dynamically-generated task resources, one per Ansible module (builtin modules strip the `ansible.builtin.` prefix, e.g. `terrible_ping`, `terrible_command`; community modules use the full dotted namespace as underscores, e.g. `terrible_community_general_git_config`)
+- `terrible_playbook` — runs an Ansible playbook file (deprecated)
+- `terrible_role` — runs an Ansible role (deprecated)
 - `terrible_vault` (data source) — decrypts Ansible Vault ciphertext
-- `terrible_datasource_ansible_builtin_*` — task data sources for modules with full check mode support
+- `terrible_datasource_*` — task data sources for modules with full check mode support
 
 Task resources are discovered dynamically from installed Ansible modules at runtime. Schemas are generated from each module's `DOCUMENTATION` and `RETURN` blocks and cached in SQLite.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Terraform state — no Ansible inventory required.
 Resource types:
 
 - `terrible_host` — target host (SSH, WinRM, local, Docker, etc.)
-- `terrible_ansible_builtin_*` — one resource per Ansible module, discovered dynamically
+- `terrible_*` — one resource per Ansible module, discovered dynamically (e.g. `terrible_ping`, `terrible_command`)
 - `terrible_vault` (data source) — decrypts Ansible Vault ciphertext
 
 > **Note:** `terrible_playbook` and `terrible_role` are deprecated and will be
@@ -41,7 +41,7 @@ resource "terrible_host" "localhost" {
   connection = "local"
 }
 
-resource "terrible_ansible_builtin_command" "hello" {
+resource "terrible_command" "hello" {
   host_id = terrible_host.localhost.id
   argv    = ["echo", "hello from Ansible"]
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -15,7 +15,7 @@ Terraform state — no Ansible inventory required.
 Resource types:
 
 - `terrible_host` — target host (SSH, WinRM, local, Docker, etc.)
-- `terrible_ansible_builtin_*` — one resource per Ansible module, discovered dynamically
+- `terrible_*` — one resource per Ansible module, discovered dynamically (e.g. `terrible_ping`, `terrible_command`)
 - `terrible_vault` (data source) — decrypts Ansible Vault ciphertext
 
 > **Note:** `terrible_playbook` and `terrible_role` are deprecated and will be
@@ -41,7 +41,7 @@ resource "terrible_host" "localhost" {
   connection = "local"
 }
 
-resource "terrible_ansible_builtin_command" "hello" {
+resource "terrible_command" "hello" {
   host_id = terrible_host.localhost.id
   argv    = ["echo", "hello from Ansible"]
 }


### PR DESCRIPTION
## Summary
- `ansible.builtin.*` modules strip the prefix and become `terrible_ping`, `terrible_command`, etc. — not `terrible_ansible_builtin_*`
- Community modules use underscored full namespace: `terrible_community_general_git_config`
- Fix index template, generated docs, and CLAUDE.md