### PR TITLE
fix: use threading reader in conftest to tolerate PyInstaller startup preamble

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "terrible"
-version = "0.8.0"
+version = "0.8.1"
 description = "Terraform provider that exposes Ansible modules as Terraform-managed resources"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,6 +18,7 @@ import os
 import re as _re
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -77,19 +78,29 @@ def provider_process():
     )
 
     reattach = None
-    for _ in range(30):
-        line = proc.stdout.readline()
-        if not line:
-            break
-        m = _REATTACH_RE.search(line)
-        if m:
-            reattach = m.group(1)
-            break
+    _lines: list[str] = []
+
+    def _scan():
+        nonlocal reattach
+        for line in proc.stdout:
+            _lines.append(line.rstrip())
+            m = _REATTACH_RE.search(line)
+            if m:
+                reattach = m.group(1)
+                return  # found it; leave remaining output to be consumed naturally
+
+    _t = threading.Thread(target=_scan, daemon=True)
+    _t.start()
+    _t.join(timeout=30)
 
     if not reattach:
         proc.kill()
         proc.wait()
-        raise RuntimeError("Provider did not emit TF_REATTACH_PROVIDERS within expected output")
+        preview = "\n".join(_lines[-20:]) if _lines else "<no output>"
+        raise RuntimeError(
+            f"Provider did not emit TF_REATTACH_PROVIDERS within 30 s\n"
+            f"Last {min(20, len(_lines))} lines of output:\n{preview}"
+        )
 
     print(f"\n[setup] Provider PID={proc.pid} started in dev/reattach mode", flush=True)
     yield reattach

--- a/uv.lock
+++ b/uv.lock
@@ -836,7 +836,7 @@ wheels = [
 
 [[package]]
 name = "terrible"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },


### PR DESCRIPTION
## Summary
- Replace the hard 30-line limit in `provider_process` with a threading-based reader that waits up to 30 s for `TF_REATTACH_PROVIDERS` with no line-count cap
- Include last 20 lines of binary output in the error message for easier debugging
- Bump to 0.8.1

## Root cause
`validate_binary` failed because the PyInstaller frozen binary emits startup output (Python/Ansible warnings via stderr, merged into stdout via `stderr=subprocess.STDOUT`) before printing `TF_REATTACH_PROVIDERS`. With only 30 lines budgeted the match was missed.

## Test plan
- [ ] CI passes (unit + integration)
- [ ] validate_binary passes in release workflow after merge