### PR TITLE
fix: use wrapper entry point for PyInstaller to avoid relative-import error

### DIFF
--- a/_terrible_main.py
+++ b/_terrible_main.py
@@ -1,0 +1,4 @@
+"""PyInstaller entry point — uses absolute import to avoid relative-import error."""
+from terrible_provider.cli import main
+
+main()

--- a/terrible.spec
+++ b/terrible.spec
@@ -23,7 +23,7 @@ jinja2_datas, jinja2_binaries, jinja2_hiddenimports = collect_all('jinja2')
 crypto_datas, crypto_binaries, crypto_hiddenimports = collect_all('cryptography')
 
 a = Analysis(
-    ['terrible_provider/cli.py'],
+    ['_terrible_main.py'],
     pathex=['.'],
     binaries=ansible_binaries + tf_binaries + grpc_binaries + crypto_binaries,
     datas=(


### PR DESCRIPTION
## Summary
- Add `_terrible_main.py` as a top-level PyInstaller entry point that uses an absolute import instead of a relative one
- Update `terrible.spec` to use `_terrible_main.py` as the entry point

## Why
PyInstaller has issues with relative imports when using `terrible_provider/cli.py` directly as the entry point. The wrapper file sidesteps this by doing `from terrible_provider.cli import main` (absolute import).

## Test plan
- [ ] CI passes (unit + integration tests, PyInstaller binary builds)