### PR TITLE
fix: force line-buffered stdout in PyInstaller entry point

### DIFF
--- a/_terrible_main.py
+++ b/_terrible_main.py
@@ -1,4 +1,10 @@
 """PyInstaller entry point — uses absolute import to avoid relative-import error."""
+import sys
+
+# Force line-buffered stdout so print() flushes on each newline when piped.
+# PYTHONUNBUFFERED=1 is unreliable inside a PyInstaller binary.
+sys.stdout.reconfigure(line_buffering=True)
+
 from terrible_provider.cli import main
 
 main()


### PR DESCRIPTION
## Summary
- Reconfigure stdout to line-buffered mode before any imports in the PyInstaller entry point
- `PYTHONUNBUFFERED=1` is not reliably honoured inside a PyInstaller binary; without this, `print()` in `tf.runner` is block-buffered and `TF_REATTACH_PROVIDERS` is never flushed to the pipe within the 30s conftest timeout

## Test plan
- [ ] CI passes (unit + integration + PyInstaller binary validation)