### PR TITLE
feat: include pywinrm in default dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,8 @@ requires-python = ">=3.13"
 dependencies = [
     "ansible>=13.3.0",
     "tf>=1.1.0",
+    "pywinrm>=0.4.0",
 ]
-
-[project.optional-dependencies]
-winrm = ["pywinrm>=0.4.0"]
 
 [project.scripts]
 terraform-provider-terrible = "terrible_provider.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -757,12 +757,8 @@ version = "0.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "ansible" },
-    { name = "tf" },
-]
-
-[package.optional-dependencies]
-winrm = [
     { name = "pywinrm" },
+    { name = "tf" },
 ]
 
 [package.dev-dependencies]
@@ -779,10 +775,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ansible", specifier = ">=13.3.0" },
-    { name = "pywinrm", marker = "extra == 'winrm'", specifier = ">=0.4.0" },
+    { name = "pywinrm", specifier = ">=0.4.0" },
     { name = "tf", specifier = ">=1.1.0" },
 ]
-provides-extras = ["winrm"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #88

Moves `pywinrm` from an optional extra into the default dependency list so WinRM support is available out of the box without needing `pip install terrible[winrm]`.