### PR TITLE
ci: mark RC/alpha/beta tags as prereleases on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Publish draft release
-        run: gh release edit "${TAG_NAME}" --draft=false
+        run: |
+          PRERELEASE=""
+          if [[ "${TAG_NAME}" =~ -(rc|alpha|beta)[0-9]*$ ]]; then
+            PRERELEASE="--prerelease"
+          fi
+          gh release edit "${TAG_NAME}" --draft=false ${PRERELEASE}
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
Closes #101

The `publish` job now detects RC/alpha/beta tags and passes `--prerelease` to `gh release edit`. Stable releases are unaffected.