### PR TITLE
ci: auto-enable squash+auto-merge on every PR

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds a workflow that automatically enables auto-merge (squash) on every PR when opened. Combined with the existing ruleset requiring resolved review threads, PRs merge once CI passes and any Copilot comments are resolved.